### PR TITLE
Add install instructions in README and package.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,9 +3,15 @@ Requirements:
 * puppeteer
 * metadata.tsv file from ncov repository
 
+To install dependencies:
+
+```bash
+$ npm install .
+```
+
 To run:
 
-```
+```bash
 $ mkdir fasta
 $ GISAID_USER=myuser GISAID_PWD=mypassword node scrape.js
 ```

--- a/package.json
+++ b/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "gisaid_scraper",
+  "version": "0.0.1",
+  "dependencies": {
+    "puppeteer": "~2"
+  }
+}


### PR DESCRIPTION
Just adds package.json and a note in the README for those who might not be so familiar with installing packages with npm.